### PR TITLE
Switch changelogs to CMS collection

### DIFF
--- a/app/components/global/elements/changelog-modal.vue
+++ b/app/components/global/elements/changelog-modal.vue
@@ -1,22 +1,114 @@
 <script setup lang="ts">
+type ReleaseNoteTranslation = {
+  languages_code?: string | null
+  name?: string | null
+  content?: string | null
+}
+
+type ReleaseNoteRecord = {
+  id: string
+  version?: string | null
+  banner?: string | null
+  date_created?: string | null
+  translations?: ReleaseNoteTranslation[] | null
+}
+
 const emit = defineEmits<{ close: [boolean] }>()
 
-const { data: patches } = await useFetch(
-  'https://ungh.cc/repos/ArisCorporation/Website/releases',
+const runtimeConfig = useRuntimeConfig()
+const releaseNoteFields = [
+  'id',
+  'version',
+  'banner',
+  'date_created',
+  'translations.languages_code',
+  'translations.name',
+  'translations.content',
+]
+
+function normalizeVersion(value?: string | null) {
+  return value?.trim().replace(/^[vV]/, '') ?? ''
+}
+
+function getPreferredTranslation(translations?: ReleaseNoteTranslation[] | null) {
+  if (!translations?.length) return null
+
+  return (
+    translations.find((translation) => translation.languages_code === 'de-DE') ??
+    translations.find((translation) => translation.languages_code === 'en-EN') ??
+    translations.find((translation) => translation.languages_code === 'en-US') ??
+    translations[0] ??
+    null
+  )
+}
+
+const currentVersion = computed(() =>
+  normalizeVersion(runtimeConfig.public.VERSION),
+)
+
+const { data: displayedPatch } = await useAsyncData(
+  'release-notes:changelog-modal',
+  async () => {
+    const rawVersion = runtimeConfig.public.VERSION?.trim()
+    const normalizedVersion = currentVersion.value
+    const versionCandidates = [...new Set([
+      rawVersion,
+      normalizedVersion || undefined,
+      normalizedVersion ? `V${normalizedVersion}` : undefined,
+      normalizedVersion ? `v${normalizedVersion}` : undefined,
+    ])].filter((value): value is string => !!value)
+
+    const matchingNotes =
+      versionCandidates.length > 0
+        ? (((await useDirectus(
+            readItems('release_notes' as any, {
+              fields: releaseNoteFields,
+              filter: {
+                status: { _eq: 'published' },
+                _or: versionCandidates.map((value) => ({
+                  version: { _eq: value },
+                })),
+              },
+              sort: ['-date_created'],
+              limit: 1,
+            }),
+          )) as ReleaseNoteRecord[]) ?? [])
+        : []
+
+    const fallbackNotes =
+      matchingNotes.length > 0
+        ? matchingNotes
+        : (((await useDirectus(
+            readItems('release_notes' as any, {
+              fields: releaseNoteFields,
+              filter: {
+                status: { _eq: 'published' },
+              },
+              sort: ['-date_created'],
+              limit: 1,
+            }),
+          )) as ReleaseNoteRecord[]) ?? [])
+
+    const matchingNote = fallbackNotes[0]
+    if (!matchingNote) return null
+
+    const translation = getPreferredTranslation(matchingNote.translations)
+
+    return {
+      id: matchingNote.id,
+      title:
+        translation?.name?.trim() ||
+        `Release Notes - Version ${matchingNote.version ?? currentVersion.value}`,
+      markdown: translation?.content?.trim() || '',
+      date: matchingNote.date_created || undefined,
+      badge: matchingNote.version || undefined,
+      image: matchingNote.banner ? getAssetId(matchingNote.banner) : undefined,
+    }
+  },
   {
-    transform: (data: any[]) => {
-      return data?.releases
-        ?.map((item: any) => ({
-          title: item.name,
-          markdown: item.markdown,
-          html: item.html,
-          createdAt: item.createdAt,
-          publishedAt: item.publishedAt,
-          tag: item.tag,
-        }))
-        .slice(0, 1)
-    },
-  }
+    default: () => null,
+    server: false,
+  },
 )
 </script>
 
@@ -30,6 +122,7 @@ const { data: patches } = await useFetch(
     >
       <template #body>
         <UChangelogVersions
+          v-if="displayedPatch"
           as="main"
           :indicator-motion="false"
           :ui="{
@@ -37,34 +130,45 @@ const { data: patches } = await useFetch(
           }"
         >
           <UChangelogVersion
-            v-for="patch in patches"
-            :key="patch.tag"
-            v-bind="patch"
+            :key="displayedPatch.id"
+            :title="displayedPatch.title"
+            :date="displayedPatch.date"
+            :badge="displayedPatch.badge"
+            :image="displayedPatch.image"
             :ui="{
               root: 'flex items-start',
               container: 'max-w-xl m-0!',
               header: 'border-b border-default pb-4',
               title: 'text-3xl',
               date: 'text-xs/9 text-highlighted font-mono',
+              imageWrapper: 'overflow-hidden rounded-2xl border border-default/60',
+              image: 'w-full object-cover',
               indicator:
                 'sticky top-0 pt-16 -mt-16 sm:pt-24 sm:-mt-24 lg:pt-32 lg:-mt-32',
             }"
           >
             <template #body>
               <MDC
-                v-if="patch.markdown"
-                :value="patch.markdown || '---'"
+                v-if="displayedPatch.markdown"
+                :key="displayedPatch.id"
+                :value="displayedPatch.markdown"
                 tag="article"
-                :key="patch.tag"
               />
             </template>
           </UChangelogVersion>
         </UChangelogVersions>
+
+        <div
+          v-else
+          class="rounded-2xl border border-dashed border-default px-6 py-10 text-center text-sm text-(--ui-text-muted)"
+        >
+          Keine Release Notes gefunden.
+        </div>
       </template>
       <template #footer>
-        <UButton variant="subtle" @click="emit('close', false)"
-          >Schließen</UButton
-        >
+        <UButton variant="subtle" @click="emit('close', false)">
+          Schließen
+        </UButton>
       </template>
     </UModal>
   </ClientOnly>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ArisCorp-Website",
-  "version": "V4.3.0",
+  "version": "V4.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This pull request updates the changelog modal component to fetch and display release notes from a Directus backend instead of the previous API, with improved version matching and localization support. It also bumps the project version to 4.3.1.

**Changelog Modal Improvements:**

* Refactored `changelog-modal.vue` to fetch release notes from Directus, including logic to select notes matching the current app version and fallback to the latest published note if none match. Added support for language-specific translations, preferring German, then English, and falling back as needed.
* Updated the modal UI to display only the most relevant release note, with improved handling for missing notes (shows a user-friendly message if none are found).

**Version Update:**

* Bumped the app version from `V4.3.0` to `V4.3.1` in `package.json`.