### PR TITLE
feat: add server-side sortable columns to all AMS tables

### DIFF
--- a/app/composables/useFetchAMSFleet.ts
+++ b/app/composables/useFetchAMSFleet.ts
@@ -1,5 +1,6 @@
 // layers/ams/composables/useUserHangarData.ts
 import type { QueryFields } from "@directus/sdk";
+import type { Ref, ComputedRef } from "vue";
 import type { Schema, UserHangar } from "~~/types";
 
 // Definiere die Felder-Struktur für bessere Lesbarkeit und Wartbarkeit
@@ -44,7 +45,7 @@ const USER_HANGAR_FIELDS: QueryFields<Schema, UserHangar> = [
   },
 ];
 
-export default function useFetchAMSFleet() {
+export default function useFetchAMSFleet(sort?: Ref<string[]> | ComputedRef<string[]>) {
   // Rufe useAsyncData mit dem reaktiven Key und der fetchData-Funktion auf.
   // Das zurückgegebene Objekt enthält data, pending, error, refresh usw.
   // und ist "awaitable", d.h. `await useUserHangarData(userId)` in der Komponente funktioniert.
@@ -61,7 +62,7 @@ export default function useFetchAMSFleet() {
           },
           fields: USER_HANGAR_FIELDS,
           limit: -1,
-          sort: ["ship.name" as any],
+          sort: (sort?.value ?? ["ship.name"]) as any,
         }),
       )) as UserHangar[];
     },

--- a/app/composables/useFetchAMSHangar.ts
+++ b/app/composables/useFetchAMSHangar.ts
@@ -1,6 +1,6 @@
 // layers/ams/composables/useUserHangarData.ts
 import type { QueryFields } from "@directus/sdk";
-import { type Ref, computed } from "vue";
+import { type Ref, type ComputedRef, computed } from "vue";
 import type { Schema, UserHangar } from "~~/types";
 
 // Definiere die Felder-Struktur für bessere Lesbarkeit und Wartbarkeit
@@ -34,7 +34,8 @@ export const USER_HANGAR_FIELDS: QueryFields<Schema, UserHangar> = [
 
 export default function useFetchAMSHangar(
   userId: Ref<string | number | undefined>,
-  routeId: string | undefined,
+  routeId?: string,
+  sort?: Ref<string[]> | ComputedRef<string[]>,
 ) {
   // Rufe useAsyncData mit dem reaktiven Key und der fetchData-Funktion auf.
   // Das zurückgegebene Objekt enthält data, pending, error, refresh usw.
@@ -51,7 +52,7 @@ export default function useFetchAMSHangar(
             ...(routeId ? { visibility: { _neq: "hidden" } } : {}),
           },
           fields: USER_HANGAR_FIELDS,
-          sort: ["ship.name"],
+          sort: (sort?.value ?? ["ship.name"]) as any,
         }),
       )) as UserHangar[];
     },

--- a/layers/ams/app/components/pages/admin/employee-table.vue
+++ b/layers/ams/app/components/pages/admin/employee-table.vue
@@ -18,8 +18,20 @@ import {
   useUserProfileEditStore,
 } from '@/stores/ams/profile-edit-store'
 
-const props = defineProps<{ data: DirectusUser[]; search: string }>()
-const emit = defineEmits(['refreshData'])
+const props = defineProps<{
+  data: DirectusUser[]
+  search: string
+  sorting: { id: string; desc: boolean }[]
+}>()
+const emit = defineEmits<{
+  (e: 'refreshData'): void
+  (e: 'update:sorting', value: { id: string; desc: boolean }[]): void
+}>()
+
+const sortingModel = computed({
+  get: () => props.sorting,
+  set: (value) => emit('update:sorting', value),
+})
 
 const expanded = ref({})
 
@@ -321,6 +333,31 @@ function generateSecureTempPassword(length = 8) {
 const UButton = resolveComponent('UButton')
 const UBadge = resolveComponent('UBadge')
 const UCheckbox = resolveComponent('UCheckbox')
+const UIcon = resolveComponent('UIcon')
+
+function sortableHeader(label: string) {
+  return ({ column }: { column: any }) =>
+    h(
+      'button',
+      {
+        class:
+          'flex items-center gap-1 text-(--ui-primary) hover:text-white transition-colors text-xs uppercase tracking-wider font-medium',
+        onClick: () => column.toggleSorting(),
+      },
+      [
+        label,
+        h(UIcon, {
+          name: !column.getIsSorted()
+            ? 'i-lucide-chevrons-up-down'
+            : column.getIsSorted() === 'asc'
+              ? 'i-lucide-chevron-up'
+              : 'i-lucide-chevron-down',
+          class: 'size-3 shrink-0',
+        }),
+      ],
+    )
+}
+
 const columns: TableColumn<DirectusUser>[] = [
   // {
   //   id: 'select',
@@ -352,12 +389,14 @@ const columns: TableColumn<DirectusUser>[] = [
   },
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: sortableHeader('Name'),
+    enableSorting: true,
     cell: ({ row }) => `${getUserLabel(row.original) ?? ''}`,
   },
   {
     accessorKey: 'status',
-    header: 'Status',
+    header: sortableHeader('Status'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         active: 'success' as const,
@@ -372,7 +411,8 @@ const columns: TableColumn<DirectusUser>[] = [
   },
   {
     accessorKey: 'role',
-    header: 'Position',
+    header: sortableHeader('Position'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         administrator: 'warning' as const,
@@ -391,13 +431,15 @@ const columns: TableColumn<DirectusUser>[] = [
   },
   {
     accessorKey: 'department',
-    header: 'Abteilung',
+    header: sortableHeader('Abteilung'),
+    enableSorting: true,
     cell: ({ row }) =>
       `${(row.original.primary_department as Department)?.name ?? ''}`,
   },
   {
     accessorKey: 'head_of_department',
-    header: 'Abteilungsleiter',
+    header: sortableHeader('Abteilungsleiter'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         true: 'primary' as const,
@@ -798,6 +840,7 @@ function getDropdownActions(user: DirectusUser): DropdownMenuItem[][] {
   >
     <UTable
       ref="teamsUiTableRef"
+      v-model:sorting="sortingModel"
       :columns="columns"
       :data="data"
       class="h-xl"

--- a/layers/ams/app/components/pages/admin/employees.vue
+++ b/layers/ams/app/components/pages/admin/employees.vue
@@ -1,6 +1,23 @@
 <script setup lang="ts">
 import type { DirectusUser } from '~~/types'
 
+const sorting = ref<{ id: string; desc: boolean }[]>([])
+
+const EMPLOYEE_SORT_MAP: Record<string, string> = {
+  name: 'first_name',
+  status: 'status',
+  role: 'role.name',
+  department: 'primary_department.name',
+  head_of_department: 'head_of_department',
+}
+const employeeSort = computed<string[]>(() =>
+  sorting.value.length
+    ? sorting.value.map(
+        ({ id, desc }) => `${desc ? '-' : ''}${EMPLOYEE_SORT_MAP[id] ?? id}`,
+      )
+    : ['first_name'],
+)
+
 const { data, refresh } = await useAsyncData<DirectusUser[]>(
   'ams:admin-employees',
   async () => {
@@ -20,12 +37,13 @@ const { data, refresh } = await useAsyncData<DirectusUser[]>(
           { primary_department: ['id', 'name', 'logo'] },
         ],
         limit: -1,
+        sort: employeeSort.value as any,
       })
     )) as DirectusUser[]
   }
 )
 
-console.log(data)
+watch(sorting, () => refresh())
 </script>
 
 <template>
@@ -42,6 +60,10 @@ console.log(data)
         </template>
       </AMSPagesAdminAddMemberSlideover>
     </div>
-    <AMSPagesAdminEmployeeTable :data="data" @refresh-data="refresh" />
+    <AMSPagesAdminEmployeeTable
+      :data="data"
+      v-model:sorting="sorting"
+      @refresh-data="refresh"
+    />
   </div>
 </template>

--- a/layers/ams/app/components/pages/fleet/ships-table.vue
+++ b/layers/ams/app/components/pages/fleet/ships-table.vue
@@ -12,12 +12,49 @@ import type {
 
 const authStore = useAuthStore()
 
-const props = defineProps<{ data: UserHangar[]; search: string }>()
+const props = defineProps<{
+  data: UserHangar[]
+  search: string
+  sorting: { id: string; desc: boolean }[]
+}>()
+const emit = defineEmits<{
+  (e: 'update:sorting', value: { id: string; desc: boolean }[]): void
+}>()
+
+const sortingModel = computed({
+  get: () => props.sorting,
+  set: (value) => emit('update:sorting', value),
+})
 
 const expanded = ref({})
 
 const UButton = resolveComponent('UButton')
 const UBadge = resolveComponent('UBadge')
+const UIcon = resolveComponent('UIcon')
+
+function sortableHeader(label: string) {
+  return ({ column }: { column: any }) =>
+    h(
+      'button',
+      {
+        class:
+          'flex items-center gap-1 text-(--ui-primary) hover:text-white transition-colors text-xs uppercase tracking-wider font-medium',
+        onClick: () => column.toggleSorting(),
+      },
+      [
+        label,
+        h(UIcon, {
+          name: !column.getIsSorted()
+            ? 'i-lucide-chevrons-up-down'
+            : column.getIsSorted() === 'asc'
+              ? 'i-lucide-chevron-up'
+              : 'i-lucide-chevron-down',
+          class: 'size-3 shrink-0',
+        }),
+      ],
+    )
+}
+
 const columns: TableColumn<UserHangar>[] = [
   {
     id: 'expand',
@@ -48,12 +85,14 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: sortableHeader('Name'),
+    enableSorting: true,
     cell: ({ row }) => `${row.original.name ?? ''}`,
   },
   {
     accessorKey: 'model',
-    header: 'Modell',
+    header: sortableHeader('Modell'),
+    enableSorting: true,
     cell: ({ row }) => `${(row.original.ship as ShipVariant).name}`,
   },
   {
@@ -64,7 +103,8 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'buy_status',
-    header: 'Kaufstatus',
+    header: sortableHeader('Kaufstatus'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         pledged: 'success' as const,
@@ -79,7 +119,8 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'visibility',
-    header: 'Sichtbarkeit',
+    header: sortableHeader('Sichtbarkeit'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         public: 'success' as const,
@@ -94,13 +135,15 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'owner',
-    header: 'Besitzer',
+    header: sortableHeader('Besitzer'),
+    enableSorting: true,
     cell: ({ row }) =>
       `${getUserLabel(row.original.user as DirectusUser) ?? ''}`,
   },
   {
     accessorKey: 'department',
-    header: 'Abteilung',
+    header: sortableHeader('Abteilung'),
+    enableSorting: true,
     cell: ({ row }) => `${(row.original.department as Department)?.name ?? ''}`,
   },
 ]
@@ -117,6 +160,7 @@ watch(props, () => {
     <UTable
       ref="teamsUiTableRef"
       v-model:expanded="expanded"
+      v-model:sorting="sortingModel"
       :columns="columns"
       :data="data"
       class="h-xl"

--- a/layers/ams/app/components/pages/hangar/ships.vue
+++ b/layers/ams/app/components/pages/hangar/ships.vue
@@ -9,12 +9,49 @@ import type {
   UserHangar,
 } from '~~/types'
 
-const props = defineProps<{ data: UserHangar[]; search: string }>()
+const props = defineProps<{
+  data: UserHangar[]
+  search: string
+  sorting: { id: string; desc: boolean }[]
+}>()
+const emit = defineEmits<{
+  (e: 'update:sorting', value: { id: string; desc: boolean }[]): void
+}>()
+
+const sortingModel = computed({
+  get: () => props.sorting,
+  set: (value) => emit('update:sorting', value),
+})
 
 const expanded = ref()
 
 const UButton = resolveComponent('UButton')
 const UBadge = resolveComponent('UBadge')
+const UIcon = resolveComponent('UIcon')
+
+function sortableHeader(label: string) {
+  return ({ column }: { column: any }) =>
+    h(
+      'button',
+      {
+        class:
+          'flex items-center gap-1 text-(--ui-primary) hover:text-white transition-colors text-xs uppercase tracking-wider font-medium',
+        onClick: () => column.toggleSorting(),
+      },
+      [
+        label,
+        h(UIcon, {
+          name: !column.getIsSorted()
+            ? 'i-lucide-chevrons-up-down'
+            : column.getIsSorted() === 'asc'
+              ? 'i-lucide-chevron-up'
+              : 'i-lucide-chevron-down',
+          class: 'size-3 shrink-0',
+        }),
+      ],
+    )
+}
+
 const columns: TableColumn<UserHangar>[] = [
   {
     id: 'expand',
@@ -45,12 +82,14 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: sortableHeader('Name'),
+    enableSorting: true,
     cell: ({ row }) => `${row.getValue('name')}`,
   },
   {
     accessorKey: 'model',
-    header: 'Modell',
+    header: sortableHeader('Modell'),
+    enableSorting: true,
     cell: ({ row }) => `${(row.original.ship as ShipVariant).name}`,
   },
   {
@@ -61,7 +100,8 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'buy_status',
-    header: 'Kaufstatus',
+    header: sortableHeader('Kaufstatus'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         pledged: 'success' as const,
@@ -76,7 +116,8 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'visibility',
-    header: 'Sichtbarkeit',
+    header: sortableHeader('Sichtbarkeit'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         public: 'success' as const,
@@ -91,7 +132,8 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'group',
-    header: 'Zuordnung',
+    header: sortableHeader('Zuordnung'),
+    enableSorting: true,
     cell: ({ row }) => {
       const color = {
         ariscorp: 'primary' as const,
@@ -105,7 +147,8 @@ const columns: TableColumn<UserHangar>[] = [
   },
   {
     accessorKey: 'department',
-    header: 'Abteilung',
+    header: sortableHeader('Abteilung'),
+    enableSorting: true,
     cell: ({ row }) => `${(row.original.department as Department)?.name ?? ''}`,
   },
   {
@@ -124,6 +167,7 @@ watch(props, () => {
     <UTable
       ref="teamsUiTableRef"
       v-model:expanded="expanded"
+      v-model:sorting="sortingModel"
       :columns="columns"
       :data="data"
       class="h-xl"

--- a/layers/ams/app/pages/ams/fleet.vue
+++ b/layers/ams/app/pages/ams/fleet.vue
@@ -6,6 +6,23 @@ const mode = useCookie<"cards" | "table">("ams:fleet-view");
 mode.value = mode.value || "cards";
 
 const searchInput = ref("");
+const sorting = ref<{ id: string; desc: boolean }[]>([]);
+
+const FLEET_SORT_MAP: Record<string, string> = {
+  name: "name",
+  model: "ship.name",
+  buy_status: "buy_status",
+  visibility: "visibility",
+  owner: "user.first_name",
+  department: "department.name",
+};
+const fleetSort = computed<string[]>(() =>
+  sorting.value.length
+    ? sorting.value.map(
+        ({ id, desc }) => `${desc ? "-" : ""}${FLEET_SORT_MAP[id] ?? id}`,
+      )
+    : ["ship.name"],
+);
 
 const viewOptions = reactive([
   {
@@ -25,7 +42,8 @@ const viewOptions = reactive([
   },
 ]);
 
-const { data, refresh } = await useFetchAMSFleet();
+const { data, refresh } = await useFetchAMSFleet(fleetSort);
+watch(sorting, () => refresh());
 
 await useSimpleDepartments();
 
@@ -87,7 +105,11 @@ definePageMeta({
       </URadioGroup>
     </div>
     <template v-if="data?.length && mode === 'table'">
-      <AMSPagesFleetShipsTable :data="filteredShips" :search="searchInput" />
+      <AMSPagesFleetShipsTable
+        :data="filteredShips"
+        :search="searchInput"
+        v-model:sorting="sorting"
+      />
     </template>
     <template v-else-if="data?.length && mode === 'cards'">
       <div

--- a/layers/ams/app/pages/ams/hangar/[[id]].vue
+++ b/layers/ams/app/pages/ams/hangar/[[id]].vue
@@ -20,6 +20,23 @@ mode.value = mode.value || 'cards'
 
 const allCardsExpanded = ref(false)
 const searchInput = ref('')
+const sorting = ref<{ id: string; desc: boolean }[]>([])
+
+const HANGAR_SORT_MAP: Record<string, string> = {
+  name: 'name',
+  model: 'ship.name',
+  buy_status: 'buy_status',
+  visibility: 'visibility',
+  group: 'group',
+  department: 'department.name',
+}
+const hangarSort = computed<string[]>(() =>
+  sorting.value.length
+    ? sorting.value.map(
+        ({ id, desc }) => `${desc ? '-' : ''}${HANGAR_SORT_MAP[id] ?? id}`,
+      )
+    : ['ship.name'],
+)
 
 const shortFilterOptions = reactive([
   { key: 'all', label: 'Alle Schiffe' },
@@ -47,8 +64,11 @@ await useSimpleDepartments()
 
 const { data, pending, refresh } = await useFetchAMSHangar(
   targetUserId,
-  routeId.value
+  routeId.value,
+  hangarSort,
 )
+
+watch(sorting, () => refresh())
 
 // Ensure fetch runs once the currentUserId is available when no id param is provided
 watch(
@@ -181,7 +201,11 @@ definePageMeta({
     </div>
 
     <template v-if="data?.length && mode === 'table'">
-      <AMSPagesHangarShips :data="filteredShips" :search="searchInput" />
+      <AMSPagesHangarShips
+        :data="filteredShips"
+        :search="searchInput"
+        v-model:sorting="sorting"
+      />
     </template>
     <template v-else-if="data?.length && mode === 'cards'">
       <div


### PR DESCRIPTION
Sorting state lives in parent pages/components and is mapped to Directus sort parameters on each user interaction, triggering a re-fetch rather than just reordering already-fetched data.

- useFetchAMSFleet / useFetchAMSHangar: accept optional reactive sort ref
- fleet.vue / hangar/[[id]].vue: own sorting state, pass to composable, watch changes
- ships-table.vue / ships.vue: accept v-model:sorting, add sortableHeader helper
- employees.vue: own sorting state, pass sort to useAsyncData closure
- employee-table.vue: accept v-model:sorting, add sortableHeader helper
- routeId param in useFetchAMSHangar made optional (fixes implicit undefined call)

Sortable columns — employees: Name, Status, Position, Abteilung, Abteilungsleiter
Sortable columns — fleet/hangar: Name, Modell, Kaufstatus, Sichtbarkeit, Abteilung (+ Besitzer/Zuordnung per table)