### PR TITLE
fix: positions without registrations are always shown as non-interactive

### DIFF
--- a/layers/ams/app/components/pages/missions/team-view.vue
+++ b/layers/ams/app/components/pages/missions/team-view.vue
@@ -351,7 +351,12 @@ function getPositionPendingCount(pos: any) {
 
 function getEffectivePositionState(pos: any) {
   const registration = getRelevantPositionRegistration(pos);
-  const status = getNormalizedRegistrationStatus(registration?.status);
+
+  if (!registration) {
+    return pos.status === "filled" ? "filled" : "open";
+  }
+
+  const status = getNormalizedRegistrationStatus(registration.status);
 
   if (status === "pending") return "pending";
   if (status === "approved" || pos.status === "filled") return "filled";


### PR DESCRIPTION
getNormalizedRegistrationStatus(undefined) returned "pending" as fallback, causing getEffectivePositionState to always return "pending" when a position had no registrations yet — making all open positions non-clickable.

Now checks registration nullability first: no registration → state is "open" (or "filled" if pos.status is filled), registration present → derive from status.